### PR TITLE
Fixed white objects in build

### DIFF
--- a/Assets/Scripts/InnerBillboard.cs
+++ b/Assets/Scripts/InnerBillboard.cs
@@ -54,7 +54,10 @@ public class InnerBillboard : MonoBehaviour
         Mat.SetVector("_CamToTexScale", new Vector4(texture.width / referenceRes.x,texture.height / referenceRes.y,0,0));
     }
 
-    void OnValidate()
+    void OnValidate() => UpdateShaderTex();
+    private void Start() => UpdateShaderTex();
+
+    void UpdateShaderTex()
     {
         Mat.SetTexture("_MainTex", texture);
     }


### PR DESCRIPTION
Previously, builds would render InnerBillboards as solid white, because the OnValidate code never ran. This has been fixed.