### PR TITLE
feat #189: thrown objects deals damage

### DIFF
--- a/Assets/Prefabs/Enemies/EnemyCarrot.prefab
+++ b/Assets/Prefabs/Enemies/EnemyCarrot.prefab
@@ -97,6 +97,78 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5172da46c4cfc08418e1a426caebf9da, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1956525852116067194
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6811506582225150429}
+  - component: {fileID: 2191074886473165252}
+  - component: {fileID: 997833942915791916}
+  m_Layer: 0
+  m_Name: ThrowingHurtBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &6811506582225150429
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1956525852116067194}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4058682035419029229}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2191074886473165252
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1956525852116067194}
+  m_Material: {fileID: 13400000, guid: 2c551137e11c43d4f8018bfd1a0d565d, type: 2}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.4894958, y: 0.4741488, z: 0.5}
+  m_Center: {x: 0, y: 0.24869111, z: 0}
+--- !u!114 &997833942915791916
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1956525852116067194}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31283c27b50b37544aeeec62d88fe053, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hitLayers:
+    serializedVersion: 2
+    m_Bits: 2048
+  damage: 30
+  parentTransform: {fileID: 4058682035419029229}
+  aura: 2
 --- !u!1 &8329304203546997834
 GameObject:
   m_ObjectHideFlags: 0
@@ -415,6 +487,10 @@ PrefabInstance:
       propertyPath: m_UseGravity
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7635130076662420740, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
+      propertyPath: throwingHurtBox
+      value: 
+      objectReference: {fileID: 997833942915791916}
     m_RemovedComponents:
     - {fileID: 5528883301703829071, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
     m_RemovedGameObjects: []
@@ -434,6 +510,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 7169455098568493955, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
       insertIndex: -1
       addedObject: {fileID: 2977149865011585263}
+    - targetCorrespondingSourceObject: {fileID: 7169455098568493955, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6811506582225150429}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 2217596612548616759, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
       insertIndex: 1

--- a/Assets/Prefabs/Enemies/ExploderEnemy.prefab
+++ b/Assets/Prefabs/Enemies/ExploderEnemy.prefab
@@ -97,6 +97,78 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5172da46c4cfc08418e1a426caebf9da, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &6971122847702156712
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7231818834087712546}
+  - component: {fileID: 9137999283128808281}
+  - component: {fileID: 1657261238787997258}
+  m_Layer: 0
+  m_Name: ThrowingHurtBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &7231818834087712546
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6971122847702156712}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.248, y: 0.273, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4058682035419029229}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &9137999283128808281
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6971122847702156712}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31283c27b50b37544aeeec62d88fe053, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hitLayers:
+    serializedVersion: 2
+    m_Bits: 2048
+  damage: 10
+  parentTransform: {fileID: 4058682035419029229}
+  aura: 2
+--- !u!65 &1657261238787997258
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6971122847702156712}
+  m_Material: {fileID: 13400000, guid: 2c551137e11c43d4f8018bfd1a0d565d, type: 2}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.4894958, y: 0.4741488, z: 0.2}
+  m_Center: {x: 0, y: 0.24869111, z: 0}
 --- !u!1 &8329304203546997834
 GameObject:
   m_ObjectHideFlags: 0
@@ -371,6 +443,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 620075631160467642, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1351190632733158541, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
       propertyPath: m_Size.x
       value: 0.4
@@ -459,6 +535,10 @@ PrefabInstance:
       propertyPath: m_UseGravity
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7635130076662420740, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
+      propertyPath: throwingHurtBox
+      value: 
+      objectReference: {fileID: 9137999283128808281}
     m_RemovedComponents:
     - {fileID: 5528883301703829071, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
     m_RemovedGameObjects: []
@@ -475,6 +555,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 7169455098568493955, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
       insertIndex: -1
       addedObject: {fileID: 2977149865011585263}
+    - targetCorrespondingSourceObject: {fileID: 7169455098568493955, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7231818834087712546}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 2217596612548616759, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
       insertIndex: 1

--- a/Assets/Prefabs/Enemies/ProjectileEnemy.prefab
+++ b/Assets/Prefabs/Enemies/ProjectileEnemy.prefab
@@ -97,6 +97,78 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5172da46c4cfc08418e1a426caebf9da, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &5605471882002004520
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6015723793833149533}
+  - component: {fileID: 829871556546830226}
+  - component: {fileID: 5169229349133540895}
+  m_Layer: 0
+  m_Name: ThrowingHurtBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6015723793833149533
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5605471882002004520}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4058682035419029229}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &829871556546830226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5605471882002004520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31283c27b50b37544aeeec62d88fe053, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hitLayers:
+    serializedVersion: 2
+    m_Bits: 2048
+  damage: 30
+  parentTransform: {fileID: 4058682035419029229}
+  aura: 2
+--- !u!65 &5169229349133540895
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5605471882002004520}
+  m_Material: {fileID: 13400000, guid: 2c551137e11c43d4f8018bfd1a0d565d, type: 2}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.4894958, y: 0.4741488, z: 0.5}
+  m_Center: {x: 0, y: 0.24869111, z: 0}
 --- !u!1 &8329304203546997834
 GameObject:
   m_ObjectHideFlags: 0
@@ -415,6 +487,10 @@ PrefabInstance:
       propertyPath: m_UseGravity
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7635130076662420740, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
+      propertyPath: throwingHurtBox
+      value: 
+      objectReference: {fileID: 829871556546830226}
     m_RemovedComponents:
     - {fileID: 5528883301703829071, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
     m_RemovedGameObjects: []
@@ -428,6 +504,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 7169455098568493955, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
       insertIndex: -1
       addedObject: {fileID: 6466315560504170389}
+    - targetCorrespondingSourceObject: {fileID: 7169455098568493955, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6015723793833149533}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 2217596612548616759, guid: 6b4c546f363b85948a083d8aa28d6311, type: 3}
       insertIndex: 1

--- a/Assets/Prefabs/Items/Item.prefab
+++ b/Assets/Prefabs/Items/Item.prefab
@@ -1,5 +1,77 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &591472837953308048
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8832558254707585632}
+  - component: {fileID: 6335588659328315274}
+  - component: {fileID: 8223698001359900932}
+  m_Layer: 0
+  m_Name: ThrowingHurtBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &8832558254707585632
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 591472837953308048}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4855111692145963414}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &6335588659328315274
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 591472837953308048}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.2664688, y: 0.33530864, z: 0.5}
+  m_Center: {x: 0, y: 0.17129408, z: 0}
+--- !u!114 &8223698001359900932
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 591472837953308048}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31283c27b50b37544aeeec62d88fe053, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hitLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  damage: 50
+  parentTransform: {fileID: 4855111692145963414}
+  aura: -1
 --- !u!1 &2680212675313349019
 GameObject:
   m_ObjectHideFlags: 0
@@ -249,6 +321,7 @@ Transform:
   - {fileID: 5662586950405697191}
   - {fileID: 8653629363206286975}
   - {fileID: 6410907685153832538}
+  - {fileID: 8832558254707585632}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &7635370847713864963
@@ -312,6 +385,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   grabIndicator: {fileID: 2680212675313349019}
+  throwingHurtBox: {fileID: 8223698001359900932}
   onGrab:
     m_PersistentCalls:
       m_Calls: []
@@ -381,6 +455,10 @@ PrefabInstance:
     - target: {fileID: 4903578636898687924, guid: 3a60d3f89bc33e54ca7cf62c5c8fe630, type: 3}
       propertyPath: m_ReceiveShadows
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5801830051146397517, guid: 3a60d3f89bc33e54ca7cf62c5c8fe630, type: 3}
+      propertyPath: m_FarClipPlane
+      value: 100.5
       objectReference: {fileID: 0}
     - target: {fileID: 6806586229155832487, guid: 3a60d3f89bc33e54ca7cf62c5c8fe630, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scenes/Build Scenes/DemoLevel02.unity
+++ b/Assets/Scenes/Build Scenes/DemoLevel02.unity
@@ -123,6 +123,39 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!21 &23473388
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Custom/InnerBillboard
+  m_Shader: {fileID: 4800000, guid: e981d8c666f2c1a4ea5cce8cfafe2304, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: 5e83f74f5a91ed84792e46c16781fb29, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats: []
+    m_Colors:
+    - _CamToTexScale: {r: 4, g: 1, b: 0, a: 0}
+    - _UvOffset: {r: -0.026907176, g: -0.00053557754, b: 0, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &32292209
 GameObject:
   m_ObjectHideFlags: 0
@@ -713,7 +746,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 1272521625}
+  - {fileID: 1243882526}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -1296,7 +1329,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2041914266722745632, guid: f3c8c46fdcfd35640b6a8ff52b61e4ec, type: 3}
       propertyPath: m_NormalizedViewPortRect.y
-      value: 0.18518518
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2041914266722745632, guid: f3c8c46fdcfd35640b6a8ff52b61e4ec, type: 3}
       propertyPath: m_NormalizedViewPortRect.width
@@ -1304,7 +1337,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2041914266722745632, guid: f3c8c46fdcfd35640b6a8ff52b61e4ec, type: 3}
       propertyPath: m_NormalizedViewPortRect.height
-      value: 0.6279761
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4516043418829481033, guid: f3c8c46fdcfd35640b6a8ff52b61e4ec, type: 3}
       propertyPath: m_Name
@@ -1388,6 +1421,39 @@ Camera:
   m_CorrespondingSourceObject: {fileID: 2041914266722745632, guid: f3c8c46fdcfd35640b6a8ff52b61e4ec, type: 3}
   m_PrefabInstance: {fileID: 497344585}
   m_PrefabAsset: {fileID: 0}
+--- !u!21 &566421951
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Custom/InnerBillboard
+  m_Shader: {fileID: 4800000, guid: e981d8c666f2c1a4ea5cce8cfafe2304, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: 5e83f74f5a91ed84792e46c16781fb29, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats: []
+    m_Colors:
+    - _CamToTexScale: {r: 4, g: 1, b: 0, a: 0}
+    - _UvOffset: {r: -0.026907176, g: -0.00053557754, b: 0, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &657279493
 GameObject:
   m_ObjectHideFlags: 0
@@ -1587,39 +1653,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2aa7a088ac1a21b3ca04b74f86ce5b31, type: 3}
---- !u!21 &915814407
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Custom/InnerBillboard
-  m_Shader: {fileID: 4800000, guid: e981d8c666f2c1a4ea5cce8cfafe2304, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 5e83f74f5a91ed84792e46c16781fb29, type: 3}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats: []
-    m_Colors:
-    - _CamToTexScale: {r: 4, g: 1, b: 0, a: 0}
-    - _UvOffset: {r: 0.0022321343, g: -0.0005354852, b: 0, a: 0}
-  m_BuildTextureStacks: []
 --- !u!43 &973038633
 Mesh:
   m_ObjectHideFlags: 0
@@ -1872,7 +1905,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2104498261}
+  - {fileID: 1313122604}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -2501,7 +2534,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 1161164261}
+  - {fileID: 23473388}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -2783,7 +2816,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 818326869}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &1161164261
+--- !u!21 &1243882526
 Material:
   serializedVersion: 8
   m_ObjectHideFlags: 0
@@ -2814,7 +2847,7 @@ Material:
     m_Floats: []
     m_Colors:
     - _CamToTexScale: {r: 4, g: 1, b: 0, a: 0}
-    - _UvOffset: {r: 0.0022321343, g: -0.0005354852, b: 0, a: 0}
+    - _UvOffset: {r: -0.026907176, g: -0.00053557754, b: 0, a: 0}
   m_BuildTextureStacks: []
 --- !u!43 &1254458044
 Mesh:
@@ -2981,39 +3014,6 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!21 &1272521625
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Custom/InnerBillboard
-  m_Shader: {fileID: 4800000, guid: e981d8c666f2c1a4ea5cce8cfafe2304, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 5e83f74f5a91ed84792e46c16781fb29, type: 3}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats: []
-    m_Colors:
-    - _CamToTexScale: {r: 4, g: 1, b: 0, a: 0}
-    - _UvOffset: {r: 0.0022321343, g: -0.0005354852, b: 0, a: 0}
-  m_BuildTextureStacks: []
 --- !u!43 &1284294996
 Mesh:
   m_ObjectHideFlags: 0
@@ -3179,6 +3179,39 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!21 &1313122604
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Custom/InnerBillboard
+  m_Shader: {fileID: 4800000, guid: e981d8c666f2c1a4ea5cce8cfafe2304, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 2800000, guid: 5e83f74f5a91ed84792e46c16781fb29, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats: []
+    m_Colors:
+    - _CamToTexScale: {r: 4, g: 1, b: 0, a: 0}
+    - _UvOffset: {r: -0.026907176, g: -0.00053557754, b: 0, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &1632008304
 GameObject:
   m_ObjectHideFlags: 0
@@ -3241,39 +3274,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1632008304}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!21 &1637715803
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Custom/InnerBillboard
-  m_Shader: {fileID: 4800000, guid: e981d8c666f2c1a4ea5cce8cfafe2304, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 5e83f74f5a91ed84792e46c16781fb29, type: 3}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats: []
-    m_Colors:
-    - _CamToTexScale: {r: 4, g: 1, b: 0, a: 0}
-    - _UvOffset: {r: 0.0022321343, g: -0.0005354852, b: 0, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1 &1704753762
 GameObject:
   m_ObjectHideFlags: 0
@@ -3802,7 +3802,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4639951686026394445, guid: 64f8a1bf7d93f1740af7fedc15338bef, type: 3}
       propertyPath: m_FarClipPlane
-      value: 0.5512335
+      value: 100.5
       objectReference: {fileID: 0}
     - target: {fileID: 4855111692145963414, guid: 64f8a1bf7d93f1740af7fedc15338bef, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3930,7 +3930,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 1637715803}
+  - {fileID: 2026388270}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -4312,7 +4312,7 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b34e2225c70a3dd4bbd5719994e1a105, type: 3}
---- !u!21 &2104498261
+--- !u!21 &2026388270
 Material:
   serializedVersion: 8
   m_ObjectHideFlags: 0
@@ -4343,7 +4343,7 @@ Material:
     m_Floats: []
     m_Colors:
     - _CamToTexScale: {r: 4, g: 1, b: 0, a: 0}
-    - _UvOffset: {r: 0.0022321343, g: -0.0005354852, b: 0, a: 0}
+    - _UvOffset: {r: -0.026907176, g: -0.00053557754, b: 0, a: 0}
   m_BuildTextureStacks: []
 --- !u!1 &2127381326
 GameObject:
@@ -4417,7 +4417,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 915814407}
+  - {fileID: 566421951}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -4783,83 +4783,83 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 112495486796179687, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 2409319910888792954, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_FarClipPlane
-      value: 0.5512335
+      value: 100.5
       objectReference: {fileID: 0}
-    - target: {fileID: 269422184631147026, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 2548223414105264527, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_LocalPosition.x
       value: -7.263
       objectReference: {fileID: 0}
-    - target: {fileID: 269422184631147026, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 2548223414105264527, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 269422184631147026, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 2548223414105264527, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.141
       objectReference: {fileID: 0}
-    - target: {fileID: 269422184631147026, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 2548223414105264527, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 269422184631147026, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 2548223414105264527, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 269422184631147026, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 2548223414105264527, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 269422184631147026, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 2548223414105264527, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 269422184631147026, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 2548223414105264527, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 269422184631147026, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 2548223414105264527, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 269422184631147026, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 2548223414105264527, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1116415113221405965, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 3431312029417158288, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.00999999
       objectReference: {fileID: 0}
-    - target: {fileID: 5370847992972462549, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 7667695532493570632, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_Name
-      value: Player
+      value: Banana
       objectReference: {fileID: 0}
-    - target: {fileID: 7931915048700996685, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 5689144789635344336, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8744580873528428989, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 6465700410564346400, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_Size.x
       value: 0.3687976
       objectReference: {fileID: 0}
-    - target: {fileID: 8744580873528428989, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 6465700410564346400, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_Size.y
       value: 0.5512734
       objectReference: {fileID: 0}
-    - target: {fileID: 8744580873528428989, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 6465700410564346400, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_Size.z
       value: 0.46869093
       objectReference: {fileID: 0}
-    - target: {fileID: 8744580873528428989, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 6465700410564346400, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_Center.x
       value: 0.047167152
       objectReference: {fileID: 0}
-    - target: {fileID: 8744580873528428989, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 6465700410564346400, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_Center.y
       value: 0.13840503
       objectReference: {fileID: 0}
-    - target: {fileID: 8744580873528428989, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+    - target: {fileID: 6465700410564346400, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
       propertyPath: m_Center.z
       value: 0
       objectReference: {fileID: 0}
@@ -4867,7 +4867,7 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 77356f5dddf51224a84256c013603b72, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 5cfb1e7c601d2494cbe4223a2c2d4b71, type: 3}
 --- !u!1001 &4031000408320180700
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Characters/Grabbable.cs
+++ b/Assets/Scripts/Characters/Grabbable.cs
@@ -28,17 +28,17 @@ public class Grabbable : MonoBehaviour
 
     public event Action disabled;
 
+
+    [Tooltip("The hurtbox to be used when throwing an object")]
+    [SerializeField] HurtBox throwingHurtBox;
+
     void Start()
     {
+        Utils.Assert(throwingHurtBox != null);
+        throwingHurtBox.gameObject.SetActive(false); // make sure it's off
+
         this.GetComponentOrError(out rb);
-        if (GetComponent<NavMeshAgent>() != null)
-        {
-            agent = GetComponent<NavMeshAgent>();
-        }
-        else
-        {
-            return;
-        }
+        agent = GetComponent<NavMeshAgent>();
     }
 
     public UnityEvent onGrab;
@@ -62,6 +62,8 @@ public class Grabbable : MonoBehaviour
         rb.isKinematic = false;
         if(agent != null)
             agent.enabled = true;
+
+        throwingHurtBox.gameObject.SetActive(true);
     }
 
     public void ForceRelease()
@@ -98,5 +100,11 @@ public class Grabbable : MonoBehaviour
 
     void OnDisable() {
         disabled?.Invoke();
+    }
+
+    void OnCollisionEnter(Collision collision) {
+        if (collision.collider.gameObject.layer == LayerMask.NameToLayer("World")) {
+            throwingHurtBox.gameObject.SetActive(false);
+        }
     }
 }

--- a/ProjectSettings/BurstAotSettings_StandaloneLinux64.json
+++ b/ProjectSettings/BurstAotSettings_StandaloneLinux64.json
@@ -1,0 +1,17 @@
+{
+  "MonoBehaviour": {
+    "Version": 4,
+    "EnableBurstCompilation": true,
+    "EnableOptimisations": true,
+    "EnableSafetyChecks": false,
+    "EnableDebugInAllBuilds": false,
+    "DebugDataKind": 1,
+    "EnableArmv9SecurityFeatures": false,
+    "CpuMinTargetX32": 0,
+    "CpuMaxTargetX32": 0,
+    "CpuMinTargetX64": 0,
+    "CpuMaxTargetX64": 0,
+    "CpuTargetsX64": 72,
+    "OptimizeFor": 0
+  }
+}


### PR DESCRIPTION
fix #189 
Thrown objects now deal damage. This is done by adding a new hurtbox to every grabbable, then pointing `Grabbable.throwingHurtBox` to the new hurtbox in the inspector. The grabbable will then enable the hurtbox when the object is thrown, and disable the hurtbox when the object collides with the world.